### PR TITLE
refactor: standardized exports

### DIFF
--- a/example/integration_test/bdk_full_cycle_test.dart
+++ b/example/integration_test/bdk_full_cycle_test.dart
@@ -4,7 +4,7 @@ import 'package:bdk_flutter/bdk_flutter.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:payjoin_flutter/common.dart' as common;
+import 'package:payjoin_flutter/payjoin_flutter.dart' as common;
 import 'package:payjoin_flutter/receive/v1.dart' as v1;
 import 'package:payjoin_flutter/send.dart' as send;
 import 'package:payjoin_flutter/uri.dart' as pay_join_uri;

--- a/example/integration_test/bitcoin_core_full_cycle_test.dart
+++ b/example/integration_test/bitcoin_core_full_cycle_test.dart
@@ -4,7 +4,7 @@ import 'package:bdk_flutter/bdk_flutter.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:payjoin_flutter/common.dart' as common;
+import 'package:payjoin_flutter/payjoin_flutter.dart' as common;
 import 'package:payjoin_flutter/uri.dart' as pay_join_uri;
 import 'package:payjoin_flutter_example/btc_client.dart';
 import 'package:payjoin_flutter_example/payjoin_library.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:bdk_flutter/bdk_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:payjoin_flutter/common.dart' as common;
+import 'package:payjoin_flutter/payjoin_flutter.dart' as common;
 import 'package:payjoin_flutter/uri.dart' as pay_join_uri;
 import 'package:payjoin_flutter_example/bdk_client.dart';
 import 'package:payjoin_flutter_example/payjoin_library.dart';

--- a/example/lib/payjoin_library.dart
+++ b/example/lib/payjoin_library.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/cupertino.dart';
-import 'package:payjoin_flutter/common.dart' as common;
+import 'package:payjoin_flutter/payjoin_flutter.dart' as common;
 import 'package:payjoin_flutter/receive/v1.dart' as v1;
 import 'package:payjoin_flutter/send.dart' as send;
 import 'package:payjoin_flutter/uri.dart' as pj_uri;

--- a/lib/payjoin_flutter.dart
+++ b/lib/payjoin_flutter.dart
@@ -1,2 +1,5 @@
+library payjoin_flutter;
+
 export 'src/exceptions.dart' hide mapPayjoinError, ExceptionBase;
 export 'src/generated/utils/types.dart';
+export 'src/generated/frb_generated.dart' show core;

--- a/lib/receive/v1.dart
+++ b/lib/receive/v1.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-import '../common.dart' as common;
-import '../common.dart';
+import '../payjoin_flutter.dart' as common;
+import '../payjoin_flutter.dart';
 import '../src/config.dart';
 import '../src/exceptions.dart';
 import '../src/generated/api/receive.dart';

--- a/lib/receive/v2.dart
+++ b/lib/receive/v2.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-import '../common.dart';
+import '../payjoin_flutter.dart';
 import '../src/exceptions.dart';
 import '../src/generated/api/receive.dart';
 import '../src/generated/utils/error.dart' as error;

--- a/lib/send.dart
+++ b/lib/send.dart
@@ -2,7 +2,7 @@ import 'package:payjoin_flutter/src/config.dart';
 import 'package:payjoin_flutter/src/exceptions.dart';
 import 'package:payjoin_flutter/uri.dart';
 
-import 'common.dart' as common;
+import 'payjoin_flutter.dart' as common;
 import 'src/generated/api/send.dart';
 import 'src/generated/api/uri.dart';
 import 'src/generated/utils/error.dart' as error;


### PR DESCRIPTION
- Rename `common` to `payjoin_flutter` (standard accross frb packages)
- Export `core` from generated because `init` is needed when working with isolates (bullbitcoin-mobile)